### PR TITLE
Allow to pass explicit types to Worksheet::fromArray()

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2476,7 +2476,7 @@ class Worksheet implements IComparable
      *
      * @return Worksheet
      */
-    public function fromArray(array $source, $nullValue = null, $startCell = 'A1', $strictNullComparison = false)
+    public function fromArray(array $source, $nullValue = null, $startCell = 'A1', $strictNullComparison = false, ?array $explicitTypes=NULL)
     {
         //    Convert a 1-D array to 2-D (for ease of looping)
         if (!is_array(end($source))) {
@@ -2489,16 +2489,16 @@ class Worksheet implements IComparable
         // Loop through $source
         foreach ($source as $rowData) {
             $currentColumn = $startColumn;
-            foreach ($rowData as $cellValue) {
+            foreach ($rowData as $pos => $cellValue) {
                 if ($strictNullComparison) {
                     if ($cellValue !== $nullValue) {
                         // Set cell value
-                        $this->getCell($currentColumn . $startRow)->setValue($cellValue);
+                        $this->_setCellValue($currentColumn, $startRow, $cellValue, $pos, $explicitTypes);
                     }
                 } else {
                     if ($cellValue != $nullValue) {
                         // Set cell value
-                        $this->getCell($currentColumn . $startRow)->setValue($cellValue);
+                        $this->_setCellValue($currentColumn, $startRow, $cellValue, $pos, $explicitTypes);
                     }
                 }
                 ++$currentColumn;
@@ -2507,6 +2507,15 @@ class Worksheet implements IComparable
         }
 
         return $this;
+    }
+
+    private function _setCellValue(string $col, string $row, $value, int $pos, ?array $explicitTypes) {
+        $cell = $this->getCell($col . $row);
+
+        if ($explicitTypes !== NULL)
+            $cell->setValueExplicit($value, $explicitTypes[$pos]);
+        else
+            $cell->setValue($value);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Functional/TypeAttributePreservationTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/TypeAttributePreservationTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Functional;
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 
 class TypeAttributePreservationTest extends AbstractFunctional
 {
@@ -47,5 +48,30 @@ class TypeAttributePreservationTest extends AbstractFunctional
         }
 
         self::assertSame($expected, $actual);
+    }
+
+    /**
+     * Ensure saved spreadsheets maintain the correct data type.
+     *
+     * @dataProvider providerFormulae
+     *
+     * @param string $format
+     * @param array $values
+     */
+    public function testFormulaeExplicit($format, array $values)
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray($values, NULL, "A1", false, [DataType::TYPE_STRING, DataType::TYPE_STRING]);
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, $format);
+        $reloadedSheet = $reloadedSpreadsheet->getActiveSheet();
+
+        $dt = $reloadedSheet->getCell('A1')->getDataType();
+
+        if ($sheet->getCell('A1')->getValue() !== NULL)
+            self::assertEquals("s", $dt);
+        else
+            self::assertEquals("null", $dt);
     }
 }


### PR DESCRIPTION
Add optional array parameter 'explicitTypes'

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Currently `fromArray()` does not allow to set explicit types.  When the data in the array contain special characters such a leading equals sign that are meaningful to Excel, data is converted to formula, whereas I want to make sure it is typed as string.