### PR TITLE
Use correct scripts paths for tools installed by composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     ],
     "scripts": {
         "check": [
-            "php-cs-fixer fix --ansi --dry-run --diff",
-            "phpcs --report-width=200 --report-summary  --report-full samples/ src/ tests/ --ignore=samples/Header.php --standard=PSR2 -n",
-            "phpunit --color=always"
+            "./vendor/bin/php-cs-fixer fix --ansi --dry-run --diff",
+            "./vendor/bin/phpcs --report-width=200 --report-summary  --report-full samples/ src/ tests/ --ignore=samples/Header.php --standard=PSR2 -n",
+            "./vendor/bin/phpunit --color=always"
         ],
         "fix": [
-            "php-cs-fixer fix --ansi"
+            "./vendor/bin/php-cs-fixer fix --ansi"
         ]
     },
     "require": {


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

`composer fix` and `composer check` fail to run without this fix.